### PR TITLE
Update ui to included needed fields in proposition/assertion display

### DIFF
--- a/src/genegraph_ui/common/events.cljs
+++ b/src/genegraph_ui/common/events.cljs
@@ -115,8 +115,7 @@
 
 
 (def resource-query
-
-  "query ($iri: String) {
+"query ($iri: String, $genetic_evidence_type: String, $experimental_evidence_type: String) {
   resource(iri: $iri) {
     ...basicFields
     ... on ProbandEvidence {
@@ -188,19 +187,31 @@ fragment statementFields on Statement {
       ...probandFields
     }
   }
-  genetic_evidence: evidence(transitive: true, class: \"SEPIO:0004083\") {
+  genetic_evidence: evidence(transitive: true, class: $genetic_evidence_type) {
     ...basicFields
-        ... on Statement {
+    ... on Statement {
       score
+      evidence {
+        ... basicFields
+        ... on ProbandEvidence {
+          ... probandFields
+        }
+      }
     }
     ... on ProbandEvidence {
       ...probandFields
     }
   }
-  experimental_evidence: evidence(transitive: true, class: \"SEPIO:0004105\") {
+  experimental_evidence: evidence(transitive: true, class: $experimental_evidence_type) {
     ...basicFields
     ... on Statement {
       score
+      evidence {
+        ... basicFields
+        ... on ProbandEvidence {
+          ... probandFields
+        }
+      }
     }
   }
   score
@@ -219,7 +230,9 @@ fragment statementFields on Statement {
  :common/select-value-object
  (fn [{:keys [db]} [_ curie]]
    (js/console.log "select value object " curie)
-   (let [params {:iri curie}
+   (let [params {:iri curie
+                 :genetic_evidence_type "SEPIO:0004083"
+                 :experimental_evidence_type "SEPIO:0004105"}
          history (if (:value-object db)
                    (cons (:value-object db)
                          (:history db))

--- a/src/genegraph_ui/views/generic_resource.cljs
+++ b/src/genegraph_ui/views/generic_resource.cljs
@@ -25,5 +25,14 @@
 
 (defmethod render-compact "GenericResource" [resource]
   ^{:key resource}
-  [:p.block (render-link resource)])
+  [:div.columns.is-multiline
+   [:div.column.is-one-third
+    [:div.break (render-link resource)]
+    (when-let [source (:source resource)]
+      [:div.break [:a.is-size-7
+                   {:href (:iri source)
+                    :title (:label source)}
+                   (:short_citation source)]])]
+   (when-let [description (:description resource)]
+     [:div.column description])])
 

--- a/src/genegraph_ui/views/proband_evidence.cljs
+++ b/src/genegraph_ui/views/proband_evidence.cljs
@@ -23,11 +23,14 @@
 (defmethod render-compact "ProbandEvidence" [evidence]
   ^{:key evidence}
   [:div.columns
-   [:div.column.is-narrow
-    [:a.icon
-     {:href (href :resource evidence)}
-     [:i.fas.fa-file]]]
-   [:div.column.is-narrow (render-link evidence)]
-   (for [variant (:variants evidence)]
-     ^{:key variant}
-     [:div.column.is-narrow (:label variant)])]) 
+   [:div.column.is-one-third (render-link evidence)
+    (when-let [source (:source evidence)]
+      [:div.break [:a.is-size-7
+                   {:href (:iri source)
+                    :title (:label source)}
+                   (:short_citation source)]])]
+   [:div.column
+    (for [variant (:variants evidence)]
+      ^{:key variant}
+      [:div.break (:label variant)])
+    [:div.break (:description evidence)]]]) 


### PR DESCRIPTION
Closes clingen-data-model/genegraph#242 (should have created that issue in this project instead...)

These include the remaining necessary detail, excepting default criteria scores, which are covered in a different issue. Did not need more additions to the Genegraph API beyond the last PR to satisfy this.